### PR TITLE
declare wider range of supported Angular versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "ts-clipboard": "1.0.14"
   },
   "peerDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0",
+    "@angular/common": ">=4 <6",
+    "@angular/core": ">=4 <6",
     "rxjs": "^5.0.1",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/compiler": "^4.0.0",
-    "@angular/compiler-cli": "^4.0.0",
-    "@angular/core": "^4.0.0",
+    "@angular/common": ">=4 <6",
+    "@angular/compiler": ">=4 <6",
+    "@angular/compiler-cli": ">=4 <6",
+    "@angular/core": ">=4 <6",
     "@types/node": "^6.0.45",
     "del": "^2.2.2",
     "gulp": "^3.9.1",


### PR DESCRIPTION
removes warnings:
npm WARN ng2-clipboard@1.0.35 requires a peer of @angular/common@^4.0.0 but none was installed.
npm WARN ng2-clipboard@1.0.35 requires a peer of @angular/core@^4.0.0 but none was installed.